### PR TITLE
Make CI post to slack when the website updates (or fails to)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,9 @@
 version: 2.1
 
 orbs:
-  gh-pages: sugarshin/gh-pages@1.0.0
-  node: circleci/node@5.0.2
+  gh-pages: sugarshin/gh-pages@1.0
+  node: circleci/node@5.0
+  slack: circleci/slack@4.10
 
 jobs:
   build-for-release:
@@ -30,6 +31,14 @@ jobs:
       - gh-pages/deploy:
           setup-git: true
           ssh-fingerprints: "67:49:0e:96:25:20:a0:35:7a:93:12:27:3e:4b:8d:e8"
+      - slack/notify:
+          template: basic_success_1
+          event: pass
+      - slack/notify:
+          template: basic_fail_1
+          event: fail
+          mentions: @eritters
+
 
 workflows:
   Build and deploy:
@@ -50,6 +59,7 @@ workflows:
           filters:
             branches:
               only: /^main$/
+          context: "Slack - BmoreCodeCoffee"
           requires:
             - "Prepare release build"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - slack/notify:
           template: basic_fail_1
           event: fail
-          mentions: @eritters
+          mentions: '@eritters'
 
 
 workflows:


### PR DESCRIPTION
# Description

* Added a new slack app to the Baltimore Tech slack so Circle can authenticate:
![image](https://user-images.githubusercontent.com/6354401/178114909-2d4bca8f-d513-4137-8346-854e45ffeab8.png)

* Added a context (only viewable & editable by organizers) which contains the slack app auth token and default channel ID (configured to be #code-and-coffee-website):
![image](https://user-images.githubusercontent.com/6354401/178114981-4043a422-fbab-4644-8ccb-124dbd57306b.png)

* Added the [slack orb](https://circleci.com/developer/orbs/orb/circleci/slack) to the CI config and added steps to the deploy job to notify slack on pass or fail

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

We won't know if it works until we merge, but I followed the setup instructions on the [Slack Orb Documentation](https://github.com/CircleCI-Public/slack-orb/wiki/Setup) so I'm confident it should

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# Notes / Details

Closes #25 